### PR TITLE
65 create incorrect username or password alert and succesfully signed up alert

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -16,7 +16,7 @@ class SignUpForm(FlaskForm):
 	username = StringField("Username",validators=[DataRequired()])
 	email = StringField('Email', validators=[DataRequired(), Email()])
 	password = PasswordField("Password",validators=[DataRequired()])
-	password2 = PasswordField('Repeat Password', validators=[DataRequired(), EqualTo('password')])
+	password2 = PasswordField('Repeat Password', validators=[DataRequired(), EqualTo('password', "Passwords must match.")])
 	signUp = SubmitField("Sign Up")
 	pronouns = RadioField("Pronouns:", validators=[InputRequired(message=None)], choices=[("She/Her", "She/Her"), ("He/Him", "He/Him"), ("They/Them","They/Them")])
 	

--- a/app/forms.py
+++ b/app/forms.py
@@ -24,14 +24,14 @@ class SignUpForm(FlaskForm):
 		user = db.session.scalar(sa.select(User).where(
 			User.username == username.data))
 		if user is not None:
-			raise ValidationError('Please use a different username.')
+			raise ValidationError('Username already in use.')
 
 	def validate_email(self, email):
 		user = db.session.scalar(sa.select(User).where(
 			User.email == email.data))
 		
 		if user is not None:
-			raise ValidationError('Please use a different email address.')
+			raise ValidationError('Email already in use.')
 
 class newPost(FlaskForm):
     title = TextAreaField('Write Title Placeholder', validators=[DataRequired(), Length(min=1, max=140)])

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, redirect, session, url_for, request
+from flask import render_template, redirect, session, url_for, request, flash
 from app import app
 from app.forms import *
 #from werkzeug.security import generate_password_hash, check_password_hash
@@ -32,6 +32,7 @@ def loginPage():
     if form.validate_on_submit():
         user = db.session.scalar(sa.select(User).where(User.username == form.username.data))
         if user is None or not user.check_password(form.password.data):
+            flash("Incorrect username or password.", 'error')
             return redirect(url_for('loginPage'))
         login_user(user, remember=form.remember_me.data)
         return redirect(url_for('index'))
@@ -72,6 +73,7 @@ def signUpPage():
         user.set_password(form.password.data)
         db.session.add(user)
         db.session.commit()
+        flash("Sign up successful! Please log in.", 'success')
         return redirect(url_for('loginPage'))
 
     return render_template("sign-up.html", title="Sign Up", form=form)

--- a/app/routes.py
+++ b/app/routes.py
@@ -54,6 +54,7 @@ def index():
             db.session.commit()
             return redirect(url_for('index'))
         else:
+            flash("Please sign in to create a post.", 'error')
             return redirect(url_for('loginPage'))
     posts = db.session.scalars(sa.select(Post).order_by(Post.timestamp.desc())).all()
     length = len(posts)+1
@@ -109,6 +110,7 @@ def postview(post_id):
     form = newComment()
     if form.validate_on_submit():
         if not current_user.is_authenticated:
+            flash("Please log in to post a comment.", 'error')
             return redirect(url_for('loginPage'))
         comment = Comments(body=form.commentBody.data, post_id=post_id, user_id=current_user.id)
         db.session.add(comment)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -247,3 +247,6 @@ hr {
     width: 80%;
 }
 
+.alert {
+    width: 75%;
+}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -248,5 +248,5 @@ hr {
 }
 
 .alert {
-    width: 75%;
+    width: 65%;
 }

--- a/app/templates/default.html
+++ b/app/templates/default.html
@@ -70,12 +70,40 @@
     </nav>
     <!-- Navbar -->
 
-    <div class="alert alert-danger alert-dismissible mx-auto mt-4" role="alert">
-      <div>
-        A simple danger alert—check it out!
-      </div>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+    <!-- {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <ul class=flashes>
+        {% for category, message in messages %}
+          <li class="{{ category }}">{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %} -->
+
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="position-absolute z-1 w-100">
+          {% for category, message in messages %}
+            {% if category == 'error' %}
+              <div class="alert alert-danger alert-dismissible mx-auto mt-4" role="alert">
+                <div>
+                  {{ message }}
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+              </div>
+            {% else %}
+              <div class="alert alert-success alert-dismissible mx-auto mt-4" role="alert">
+                <div>
+                  {{ message }}
+                </div>
+                <buttom type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></buttom>
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
     
     {% block body_content %}{% endblock %}
 

--- a/app/templates/default.html
+++ b/app/templates/default.html
@@ -69,6 +69,14 @@
       </div>
     </nav>
     <!-- Navbar -->
+
+    <div class="alert alert-danger alert-dismissible mx-auto mt-4" role="alert">
+      <div>
+        A simple danger alert—check it out!
+      </div>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    
     {% block body_content %}{% endblock %}
 
     <script

--- a/app/templates/sign-up.html
+++ b/app/templates/sign-up.html
@@ -9,45 +9,53 @@
               <img src="/static/ThinkMad.svg" class="d-block mx-auto my-4" />
               <form name="signUp" , action="" , method="post">
                 {{form.hidden_tag()}}
-                <div class="form-floating">
+                <div class="form-floating {% if form.username.errors %}is-invalid{% endif %}">
                   {{form.username(placeholder="Username", size=8,
-                  class="form-control mb-2", id="signUpUsername", type="text")}}
+                  class="form-control mb-2" ~ (' is-invalid' if form.username.errors else ''), id="signUpUsername", type="text")}}
                   <label class="my-0" for="signUpUsername">Username</label>
                 </div>
                 {% for error in form.username.errors %}
-                <span style="color: red">[{{ error}}</span>
+                <div class="invalid-feedback mb-1">
+                  {{ error }}
+                </div>
                 {% endfor %}
-                <div class="form-floating">
+                <div class="form-floating {% if form.email.errors %}is-invalid{% endif %}">
                   {{form.email(placeholder="Email", size=8, class="form-control
-                  mb-2", id="signUpEmail", type="text")}}
+                  mb-2" ~ (' is-invalid' if form.email.errors else ''), id="signUpEmail", type="text")}}
                   <label class="form-label my-0" for="signUpEmail">Email</label>
                 </div>
                 {% for error in form.email.errors %}
-                <span style="color: red">[{{ error}}</span>
+                  <div class="invalid-feedback mb-1">
+                    {{ error }}
+                  </div>
                 {% endfor %}
                 <!-- <input class="form-control" type="text" id="signUpUsername" placeholder="Username"><br> -->
-                <div class="form-floating">
+                <div class="form-floating {% if form.password.errors %}is-invalid{% endif %}">
                   {{form.password(placeholder="Password", size=8,
-                  class="form-control mb-2", id="signUpPassword",
+                  class="form-control mb-2" ~ (' is-invalid' if form.password.errors else ''), id="signUpPassword",
                   type="password")}}
                   <label class="form-label my-0" for="signUpPassword"
                     >Password</label
                   >
                 </div>
                 {% for error in form.password.errors %}
-                <span style="color: red">[{{ error}}</span>
+                <div class="invalid-feedback mb-1">
+                  {{ error }}
+                </div>
                 {% endfor %}
                 <!-- <input class="form-control" type="password" id="signUpPassword" placeholder="Password"><br> -->
-                <div class="form-floating">
+                <div class="form-floating {% if form.password2.errors %}is-invalid{% endif %}">
                   {{form.password2(placeholder="Confirm password", size=8,
-                  class="form-control mb-2", id="signUpConfirmPassword",
+                  class="form-control mb-2" ~ (' is-invalid' if form.password2.errors else ''), id="signUpConfirmPassword",
                   type="password")}}
                   <label class="form-label my-0" for="signUpConfirmPassword"
                     >Confirm password</label
                   >
                 </div>
-                {% for error in form.password.errors %}
-                <span style="color: red">[{{ error}}</span>
+                {% for error in form.password2.errors %}
+                <div class="invalid-feedback mb-1">
+                  {{ error }}
+                </div>
                 {% endfor %}
                 <!-- <input class="form-control" type="password" id="signUpConfirmPassword" placeholder="Confirm password"><br> -->
 


### PR DESCRIPTION
I have added alerts that will show on the login page. These alerts include:
-  An error alert when username or password is incorrect
![image](https://github.com/K-Straiton/CITS3403-Project/assets/99306463/94204cee-d280-4e64-ae7e-b510101b099c)
- An error alert that shows up after being redirected to login after attempting to make a post without being signed in
![image](https://github.com/K-Straiton/CITS3403-Project/assets/99306463/0f669850-1543-4d85-9e43-b9da1575ac1c)
- An error alert that shows up after being redirected to login after attempting to post a comment without being signed in
![image](https://github.com/K-Straiton/CITS3403-Project/assets/99306463/ce6f571a-4e62-45ea-8102-b6583173f500)
- A success alert when redirected to login after successfully signing up
![image](https://github.com/K-Straiton/CITS3403-Project/assets/99306463/c3062dd9-81a5-4404-81f0-79438c9d4eab)


I have also changed the style of the errors that appear on the sign up page when fields are incorrect. They now use the bootstrap 'is-invalid' class and style for errors instead of plain spans.

![image](https://github.com/K-Straiton/CITS3403-Project/assets/99306463/158bec58-f1b8-4ee2-b9be-0a6ff286830b)