### PR TITLE
Fixed issue with navbar slightly overlapping body content

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -23,6 +23,10 @@ body {
     padding-top: 50px;
 }
 
+.body-content {
+    margin-top: 15px;
+}
+
 
 .text-muted {
     color: var(--tokyoNight-accent) !important;

--- a/app/templates/default.html
+++ b/app/templates/default.html
@@ -113,7 +113,9 @@
       {% endif %}
     {% endwith %}
     
-    {% block body_content %}{% endblock %}
+    <div class="body-content pt-5">
+      {% block body_content %}{% endblock %}
+    </div>
 
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "default.html" %}
 {% block page_title %}ThinkMad Home{% endblock %}
 {% block body_content %}
-<div class="d-flex justify-content-center mt-5">
+<div class="d-flex justify-content-center">
     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#newPostModal">New Post +</button>
 </div>
 {% include '_new-post-modal.html' %}
-<div id="post-scrollable-content" class="container-xl  align-self-center" style="height: 100vh; ">
+<div id="post-scrollable-content" class="container-xl  align-self-center">
     {% block content %}
         {% for post in posts %}
             {% include '_post.html' %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %} 
 {% block page_title %}ThinkMad Login{% endblock %}
 {% block body_content %}
-<div class="container-fluid vh-100">
+<div class="container-fluid">
   <div class="row h-100 p-0">
     <div class="col-10 col-sm-7 col-md-5 col-lg-4 mx-auto align-self-center">
       <div class="row">

--- a/app/templates/post-view.html
+++ b/app/templates/post-view.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %} 
 {% block page_title %}ThinkMad - {{post.title}}{% endblock %}
 {% block body_content %}
-        <div class="align-self-center mt-5 w-75 mx-auto ">
+        <div class="align-self-center w-75 mx-auto ">
         <div class="card posts-homepage mt-5 border rounded w-75 mx-auto align-self-center">
             <div class="card-body">
                 <h5 class="card-title"><a href="{{ url_for('postview', post_id=post.id)}}" > {{ post.title }} </a> </h5>

--- a/app/templates/post-view.html
+++ b/app/templates/post-view.html
@@ -2,7 +2,7 @@
 {% block page_title %}ThinkMad - {{post.title}}{% endblock %}
 {% block body_content %}
         <div class="align-self-center w-75 mx-auto ">
-        <div class="card posts-homepage mt-5 border rounded w-75 mx-auto align-self-center">
+        <div class="card posts-homepage border rounded w-75 mx-auto align-self-center">
             <div class="card-body">
                 <h5 class="card-title"><a href="{{ url_for('postview', post_id=post.id)}}" > {{ post.title }} </a> </h5>
                 <p class="align-self-center mt-2"> > <a href="{{ url_for('userview', username= post.author.username)}}" >{{ post.author.username }}</a>>  > {{moment(post.timestamp).format('MMMM Do YYYY h:mm a')}} > {{commentNumber}} Replies </p>   

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %} {% block page_title %}ThinkMad Profile - {{name}}{%
 endblock %} {% block body_content %}
 <div class="container-fluid">
-  <div class="row d-flex justify-content-center h-100 mt-5">
+  <div class="row d-flex justify-content-center h-100">
     <div class="col-sm-10 col-lg-8">
       <div class="rounded">
         <div class="row">

--- a/app/templates/sign-up.html
+++ b/app/templates/sign-up.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %} 
 {% block page_title %}ThinkMad Sign Up{% endblock %}
 {% block body_content %}
-    <div class="container-fluid vh-100">
+    <div class="container-fluid">
       <div class="row d-flex justify-content-center h-100">
         <div class="col-10 col-sm-7 col-md-5 col-lg-4 align-self-center">
           <div class="row">

--- a/app/templates/userview.html
+++ b/app/templates/userview.html
@@ -1,7 +1,7 @@
 {% extends "default.html" %} {% block page_title %}ThinkMad Profile - {{name}}{%
     endblock %} {% block body_content %}
     <div class="container-fluid">
-        <div class="row d-flex justify-content-center h-100 mt-5">
+        <div class="row d-flex justify-content-center h-100">
         <div class="col-sm-10 col-lg-8">
             <div class="rounded">
             <div class="row">


### PR DESCRIPTION
The navbar was slightly overlapping the content space. Pages also had unnecessary scrolling when there was little content due to all the body blocks being set to 100 viewport height. 